### PR TITLE
Fix error when parsing font weights like 'ExtraBold' and 'ExtraLight'

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -23,12 +23,15 @@ export const toFontWeight = (fontStyle: string) => {
 
   const supportedFontWeights: Record<string, number> = {
     thin: 100,
+    extralight: 200,
     "extra light": 200,
     light: 300,
     regular: 400,
     medium: 500,
+    semibold: 600,
     "semi bold": 600,
     bold: 700,
+    extrabold: 800,
     "extra bold": 800,
   }
 


### PR DESCRIPTION
This fixes a bug where the plugin would fail to parse `ExtraBold` into a font weight it recognized.